### PR TITLE
For `get:apps/inspect`: 1) Changed regex to match application name (w…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ co_auth_commit.sh
 node_modules
 package-lock.json
 .DS_Store
+keys/

--- a/ansible/setup_manager.yml
+++ b/ansible/setup_manager.yml
@@ -49,10 +49,20 @@
       copy:
         src: ../assets/
         dest: /
+    - name: Restrict access to TLS cert document (transferred over in prior command)
+      command: chmod 600 /letsencrypt/acme.json
 - name: Deploy traefik stack
   hosts: managers
   become: true
   tasks:
+    - name: Populate traefik static config with userEmail
+      template:
+        src: ../assets/traefik.yaml
+        dest: /traefik.yaml
+    - name: Populate grafana static config with default email
+      template:
+        src: ../assets/grafana/provisioning/datasources/datasource.yml
+        dest: /grafana/provisioning/datasources/datasource.yml
     - name: Populate traefik-prometheus-grafana compose file and copy to manager
       template:
         src: ../assets/stack-traefik-main.yaml

--- a/ansible/update_monitor_domains.yml
+++ b/ansible/update_monitor_domains.yml
@@ -3,13 +3,15 @@
   hosts: managers
   become: true
   tasks:
-    - name: Copy assets directory to manager nodes
-      copy:
-        src: ../assets/
-        dest: /
-    - name: Populate traefik-prometheus-grafana compose file and copy to manager
+    - name: Populate grafana's datasource.yml with new domain and copy to manager
+      template:
+        src: ../assets/grafana/provisioning/datasources/datasource.yml
+        dest: /grafana/provisioning/datasources/datasource.yml
+    - name: Populate traefik-prometheus-grafana.yml compose file and copy to manager
       template:
         src: ../assets/stack-traefik-main.yaml
         dest: /stack-traefik-main.yaml
-    - name: Update traefik stack
+    - name: Stop grafana service so when it is restarted, it registers new domain in datasource.yml
+      command: sudo docker service rm traefik_grafana
+    - name: Update traefik stack with new dynamic configs
       command: sudo docker stack deploy -c /stack-traefik-main.yaml traefik

--- a/assets/grafana/provisioning/datasources/datasource.yml
+++ b/assets/grafana/provisioning/datasources/datasource.yml
@@ -18,7 +18,7 @@ datasources:
   # <int> org id. will default to orgId 1 if not specified
   orgId: 1
   # <string> url
-  url: https://prometheus-2.michaelfatigati.com
+  url: https://{{ prometheusHostName|default("prometheus.example.com", true) }}
   # <string> database password, if used
   password:
   # <string> database user, if used

--- a/assets/stack-canary.yaml
+++ b/assets/stack-canary.yaml
@@ -3,7 +3,7 @@
 version: "3.7"
 
 services:
-  cat-production:
+  production:
     image: dsessler7/catnip:production
     networks:
       - traefik-public
@@ -28,7 +28,7 @@ services:
         # Canary approach
         - traefik.http.routers.app_router.service=canary@file
         - traefik.http.services.production_svc.loadbalancer.server.port=5000
-  cat-canary:
+  canary:
     image: dsessler7/catnip:canary2
     networks:
       - traefik-public

--- a/assets/traefik.yaml
+++ b/assets/traefik.yaml
@@ -52,8 +52,8 @@ metrics:
 certificatesResolvers:
   myresolver:
     acme:
-      email: fatigati.michael@gmail.com
-      storage: /assets/letsencrypt/acme.json
+      email: {{ userEmail|default("example@email.com", true) }}
+      storage: assets/letsencrypt/acme.json
       tlsChallenge: {}
       caServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
 

--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -84,14 +84,15 @@ module.exports = {
 
     let serviceName = req.params.appName;
     let regex = /.*(?=[_-])/;
-    let serviceNameFirstPart = serviceName.match(regex)[0];
+    // let serviceNameFirstPart = serviceName.match(regex)[0];
 
     try {
       let services = await AXIOS.get(`http://${managerIP}:2375/services`)
       services = services.data;
       services = services.filter(record => {
         let firstPart = record.Spec.Name.match(regex)[0];
-        return firstPart === serviceNameFirstPart;
+        // return firstPart === serviceNameFirstPart;
+        return firstPart === serviceName;
       });
       services = services.map(record => {
         return {
@@ -128,22 +129,27 @@ module.exports = {
           }
         })
       });
+
       let message = "";
       if (result.length > 1) {
         if (anyNotRunning) {
-          message = `This service has a canary version, and there seems to be a problem with either an instance of the canary version, or the production version. See "taskStatus" details below.
-For more information on app performance, visit the prometheus and grafana dashboards you have configured with SENTINEL MONITOR INIT, or inspect app logs with SENTINEL INSPECT LOGS`;
+          message = `This service has a canary version, and there may be a problem with either an instance of the canary version, or the production version. See "taskStatus" details below.
+
+For more information on app performance, visit the prometheus and grafana dashboards you have configured with SENTINEL METRICS, or inspect app logs with SENTINEL INSPECT LOGS. You can also view system level metrics for your compute instances with SENTINEL CLUSTER INSPECT.`;
         } else {
           message = `This service has a canary version, and all instances of canary and production appear to be running. See "taskStatus" details below.
-For more information on app performance, visit the prometheus and grafana dashboards you have configured with SENTINEL MONITOR INIT, or inspect app logs with SENTINEL INSPECT LOGS`;
+
+For more information on app performance, visit the prometheus and grafana dashboards you have configured with SENTINEL METRICS, or inspect app logs with SENTINEL INSPECT LOGS. You can also view system level metrics for your compute instances with SENTINEL CLUSTER INSPECT.`;
         }
       } else {
         if (anyNotRunning) {
-          message = `This service has no canary version, but there seems to be a problem with the production version. See "taskStatus" details below.
-For more information on app performance, visit the prometheus and grafana dashboards you have configured with SENTINEL MONITOR INIT, or inspect app logs with SENTINEL INSPECT LOGS.`;
+          message = `This service has no canary version, but there may be a problem with the production version. See "taskStatus" details below.
+
+For more information on app performance, visit the prometheus and grafana dashboards you have configured with SENTINEL METRICS, or inspect app logs with SENTINEL INSPECT LOGS.. You can also view system level metrics for your compute instances with SENTINEL CLUSTER INSPECT.`;
         } else {
           message = `This service has no canary version, and all instances appear to be running. See "taskStatus" details below.
-For more information on app performance, visit the prometheus and grafana dashboards you have configured with SENTINEL MONITOR INIT, or inspect app logs with SENTINEL INSPECT LOGS`;
+
+For more information on app performance, visit the prometheus and grafana dashboards you have configured with SENTINEL METRICS, or inspect app logs with SENTINEL INSPECT LOGS. You can also view system level metrics for your compute instances with SENTINEL CLUSTER INSPECT.`;
         }
       }
 


### PR DESCRIPTION
…e’re expecting just, e.g., “employee” or “catnip”), 2) Changed command in response to `sentinel metrics` instead of sentinel monitor init; For `get:clusture/metrics/domains`: 1) don't copy unnecessary files in update_monitor_domains.yml, 2) implement proper template and default values for `stack-traefik-main` and `datasource.yml`, 3) stop grafana service and redeploy traefik stack so that the datasource change is noticed; For TLS: 1) Make email in traefik.yml template-able (setupmanager.yml), 2) Pass user email to template upon initialization, 3) Make sure we chmod 600 acme.json

Co-authored-by: Samantha Lipari <samanthalipari@gmail.com>
Co-authored-by: Drew Sessler <drew.sessler@gmail.com>
Co-authored-by: Brendan Leal <leal.brendan@gmail.com>