### PR TITLE
Added sticky session functionality.

### DIFF
--- a/ansible/adjust_traffic.yml
+++ b/ansible/adjust_traffic.yml
@@ -5,5 +5,5 @@
   tasks:
     - name: Populate dynamic config template and transfer
       template:
-        src: ../assets/template_dynamic_config.yml
+        src: ../assets/template_{{ appName }}_dynamic_config.yml
         dest: /conf.d/{{ appName }}_dynamic.yml

--- a/ansible/deploy_canary_no_db.yml
+++ b/ansible/deploy_canary_no_db.yml
@@ -9,13 +9,20 @@
     - name: Create canary scale template
       template: src=../assets/template_canary_no_db_scale.yml dest=../assets/template_{{ appName }}_canary_set_scale.yml
       delegate_to: localhost
+- name: Create template for changing traffic weights
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Create dynamic config template
+      template: src=../assets/template_dynamic_config{{ sticky }}.yml dest=../assets/template_{{ appName }}_dynamic_config.yml
+      delegate_to: localhost
 - name: Transfer dynamic config to manager
   hosts: managers
   become: true
   tasks:
     - name: Populate dynamic config template and transfer
       template:
-        src: ../assets/template_dynamic_config.yml
+        src: ../assets/template_{{ appName }}_dynamic_config.yml
         dest: /conf.d/{{ appName }}_dynamic.yml
 - name: Transfer templates to the manager
   hosts: managers

--- a/ansible/deploy_canary_with_db.yml
+++ b/ansible/deploy_canary_with_db.yml
@@ -9,13 +9,20 @@
     - name: Create canary scale template
       template: src=../assets/template_canary_with_db_scale.yml dest=../assets/template_{{ appName }}_canary_set_scale.yml
       delegate_to: localhost
+- name: Create template for changing traffic weights
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Create dynamic config template
+      template: src=../assets/template_dynamic_config{{ sticky }}.yml dest=../assets/template_{{ appName }}_dynamic_config.yml
+      delegate_to: localhost
 - name: Transfer dynamic config to manager
   hosts: managers
   become: true
   tasks:
     - name: Populate dynamic config template and transfer
       template:
-        src: ../assets/template_dynamic_config.yml
+        src: ../assets/template_{{ appName }}_dynamic_config.yml
         dest: /conf.d/{{ appName }}_dynamic.yml
 - name: Transfer templates to the manager
   hosts: managers

--- a/assets/template_dynamic_config_sticky.yml
+++ b/assets/template_dynamic_config_sticky.yml
@@ -7,3 +7,8 @@ http:
             weight: {{ '{{ productionWeight|default(2) }}' }} # FIXME: CHANGE DEFAULT TO 95
           - name: {{ appName }}_canary_svc@docker
             weight: {{ '{{ canaryWeight|default(1) }}' }} # FIXME: CHANGE DEFAULT TO 5
+        sticky:
+          cookie:
+            name: {{ appName }}_session
+            secure: true
+            httpOnly: true

--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -255,6 +255,8 @@ module.exports = {
     const dbPassword = req.body.dbPassword;
     const dbName = req.body.dbName;
     const dbHost = req.body.dbHost;
+    const isSticky = req.body.isSticky;
+    const sticky = isSticky ? "_sticky" : "";
 
     const manager = createDockerAPIConnection();
     const productionService = manager.getService(`${appName}_production`);
@@ -277,6 +279,7 @@ module.exports = {
         dbName,
         dbHost,
         scaleNumber,
+        sticky,
       });
     } else {
       playbook = new Ansible.Playbook().playbook('ansible/deploy_canary_no_db').variables({
@@ -289,6 +292,7 @@ module.exports = {
         canaryWeight,
         productionWeight,
         scaleNumber,
+        sticky,
       });
     }
     playbook.inventory('ansible/inventory/hosts');


### PR DESCRIPTION
API's canary deploy route now expects a "isSticky" boolean key/value in the body.

Co-authored-by: Michael Fatigati <fatigati.michael@gmail.com>
Co-authored-by: Samantha Lipari <samanthalipari@gmail.com>
Co-authored-by: Brendan Leal <leal.brendan@gmail.com>